### PR TITLE
Ensure Using_Gtid exists before accessing it

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,7 +106,7 @@
     - replica.Is_Replica
     - replica.Slave_IO_Running == 'Yes'
     - replica.Slave_SQL_Running == 'Yes'
-    - replica.Using_Gtid == 'No'
+    - replica.Using_Gtid is defined and replica.Using_Gtid == 'No'
 
 - name: Configure replication on the replica.
   mysql_replication:


### PR DESCRIPTION
Prevent an error when mysql_replication_gtid=yes but target is still Oracle MySQL.

Fixes https://github.com/Deveryware/ansible-role-mysql-replication/issues/4