### PR TITLE
Allow check mode to be run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,7 @@
   delegate_to: "{{ mysql_replication_primary }}"
 
 - name: Get replica replication status.
+  check_mode: false
   community.mysql.mysql_replication:
     mode: getreplica
     login_unix_socket: "{{ mysql_socket }}"


### PR DESCRIPTION
Run get replica status even in check mode. It won't change anything:
- task does nothing on servers
- When task fail, it means that servers are not configured properly, and i will have fail on next task anyway.
This allow next task to be run in check mode without failing.